### PR TITLE
Added fast_sync mode.

### DIFF
--- a/tap_mysql/__init__.py
+++ b/tap_mysql/__init__.py
@@ -183,7 +183,7 @@ def get_binlog_streams(mysql_conn, catalog, config, state):
 
 
 
-def do_sync_incremental(mysql_conn, catalog_entry, state, columns):
+def do_sync_incremental(mysql_conn, catalog_entry, state, columns, batch):
     LOGGER.info("Stream %s is using incremental replication", catalog_entry.stream)
 
     md_map = metadata.to_map(catalog_entry.metadata)
@@ -196,7 +196,7 @@ def do_sync_incremental(mysql_conn, catalog_entry, state, columns):
     write_schema_message(catalog_entry=catalog_entry,
                          bookmark_properties=[replication_key])
 
-    incremental.sync_table(mysql_conn, catalog_entry, state, columns)
+    incremental.sync_table(mysql_conn, catalog_entry, state, columns, batch)
 
     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
@@ -319,7 +319,7 @@ def sync_non_binlog_streams(mysql_conn, non_binlog_catalog, config, state):
             log_engine(mysql_conn, catalog_entry)
 
             if replication_method == 'INCREMENTAL':
-                do_sync_incremental(mysql_conn, catalog_entry, state, columns)
+                do_sync_incremental(mysql_conn, catalog_entry, state, columns, batch)
             elif replication_method == 'LOG_BASED':
                 do_sync_historical_binlog(mysql_conn, catalog_entry, state, columns, batch)
             elif replication_method == 'FULL_TABLE':

--- a/tap_mysql/sync_strategies/common.py
+++ b/tap_mysql/sync_strategies/common.py
@@ -1,15 +1,22 @@
 #!/usr/bin/env python3
 # pylint: disable=missing-function-docstring,too-many-arguments,too-many-locals
+import os
 import copy
 import datetime
 import singer
 import time
+import json
+import uuid
 
+from pathlib import Path
 from singer import metadata, utils, metrics
 
 from tap_mysql.stream_utils import get_key_properties
 
 LOGGER = singer.get_logger('tap_mysql')
+
+HOME = str(Path.home())
+DEFAULT_FAST_SYNC_PATH = os.path.join(HOME, '.pipelinewise/tap_mysql_fast_sync_tmp/', str(uuid.uuid4()))
 
 
 def escape(string):
@@ -132,10 +139,20 @@ def whitelist_bookmark_keys(bookmark_key_set, tap_stream_id, state):
         singer.clear_bookmark(state, tap_stream_id, bookmark_key)
 
 
-def sync_query(cursor, catalog_entry, state, select_sql, columns, stream_version, params):
-    replication_key = singer.get_bookmark(state,
-                                          catalog_entry.tap_stream_id,
-                                          'replication_key')
+def get_new_batch_file_path(table_name, file_index, base_path=DEFAULT_FAST_SYNC_PATH):
+    file_name = table_name + '_' + str(file_index).zfill(6) + '.jsonl'
+    base_path = os.path.join(
+        base_path, table_name
+    )
+    if not os.path.exists(base_path):
+        os.makedirs(base_path)
+    return os.path.join(base_path, file_name)
+
+
+def sync_query(cursor, catalog_entry, state, select_sql, columns, stream_version, params, batch=False):
+    replication_key = singer.get_bookmark(
+        state, catalog_entry.tap_stream_id, 'replication_key'
+    )
 
     query_string = cursor.mogrify(select_sql, params)
 
@@ -144,59 +161,122 @@ def sync_query(cursor, catalog_entry, state, select_sql, columns, stream_version
     LOGGER.info('Running %s', query_string)
     cursor.execute(select_sql, params)
 
-    row = cursor.fetchone()
-    rows_saved = 0
-
     database_name = get_database_name(catalog_entry)
+
+    md_map = metadata.to_map(catalog_entry.metadata)
+    stream_metadata = md_map.get((), {})
+    replication_method = stream_metadata.get('replication-method')
 
     with metrics.record_counter(None) as counter:
         counter.tags['database'] = database_name
         counter.tags['table'] = catalog_entry.table
 
-        while row:
-            counter.increment()
-            rows_saved += 1
-            record_message = row_to_singer_record(catalog_entry,
-                                                  stream_version,
-                                                  row,
-                                                  columns,
-                                                  time_extracted)
-            singer.write_message(record_message)
+        rows_saved = 0
 
-            md_map = metadata.to_map(catalog_entry.metadata)
-            stream_metadata = md_map.get((), {})
-            replication_method = stream_metadata.get('replication-method')
-
-            if replication_method in {'FULL_TABLE', 'LOG_BASED'}:
-                key_properties = get_key_properties(catalog_entry)
-
-                max_pk_values = singer.get_bookmark(state,
-                                                    catalog_entry.tap_stream_id,
-                                                    'max_pk_values')
-
-                if max_pk_values:
-                    last_pk_fetched = {k:v for k, v in record_message.record.items()
-                                       if k in key_properties}
-
-                    state = singer.write_bookmark(state,
-                                                  catalog_entry.tap_stream_id,
-                                                  'last_pk_fetched',
-                                                  last_pk_fetched)
-
-            elif replication_method == 'INCREMENTAL':
-                if replication_key is not None:
-                    state = singer.write_bookmark(state,
-                                                  catalog_entry.tap_stream_id,
-                                                  'replication_key',
-                                                  replication_key)
-
-                    state = singer.write_bookmark(state,
-                                                  catalog_entry.tap_stream_id,
-                                                  'replication_key_value',
-                                                  record_message.record[replication_key])
-            if rows_saved % 1000 == 0:
-                singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
+        if replication_method == 'INCREMENTAL' or not batch:
 
             row = cursor.fetchone()
+            while row:
+                counter.increment()
+                rows_saved += 1
+                record_message = row_to_singer_record(
+                    catalog_entry,
+                    stream_version,
+                    row,
+                    columns,
+                    time_extracted
+                )
+
+                singer.write_message(record_message)
+
+                if replication_method in {'FULL_TABLE', 'LOG_BASED'}:
+                    key_properties = get_key_properties(catalog_entry)
+
+                    max_pk_values = singer.get_bookmark(state,
+                                                        catalog_entry.tap_stream_id,
+                                                        'max_pk_values')
+
+                    if max_pk_values:
+                        last_pk_fetched = {k:v for k, v in record_message.record.items()
+                                        if k in key_properties}
+
+                        state = singer.write_bookmark(state,
+                                                    catalog_entry.tap_stream_id,
+                                                    'last_pk_fetched',
+                                                    last_pk_fetched)
+
+                elif replication_method == 'INCREMENTAL':
+                    if replication_key is not None:
+                        state = singer.write_bookmark(state,
+                                                    catalog_entry.tap_stream_id,
+                                                    'replication_key',
+                                                    replication_key)
+
+                        state = singer.write_bookmark(state,
+                                                    catalog_entry.tap_stream_id,
+                                                    'replication_key_value',
+                                                    record_message.record[replication_key])
+                if rows_saved % 1000 == 0:
+                    singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
+
+                row = cursor.fetchone()
+
+        else:
+            LOGGER.debug("Running extract in batch mode.")
+            export_batch_rows = 50000
+            batch_file_index = 0
+
+            rows = cursor.fetchmany(export_batch_rows)
+            while rows:
+                counter.increment(amount=len(rows))
+                rows_saved += len(rows)
+
+                # Write records to json lines file
+                file_path = get_new_batch_file_path(catalog_entry.table, batch_file_index)
+                with open(file_path, 'w') as f:
+                    for row in rows:
+                        record = row_to_singer_record(
+                            catalog_entry, stream_version,
+                            row, columns, time_extracted
+                        )
+                        f.write(json.dumps(record.record))
+                        f.write('\n')
+
+                # Create new 'batch' type record with file path
+                batch_record = {
+                    '__fast_sync_message__': True,
+                    'file_path': file_path
+                }
+                # Write batch record
+                singer.write_message(
+                    singer.RecordMessage(
+                        stream=catalog_entry.stream,
+                        record=batch_record,
+                        version=stream_version,
+                        time_extracted=time_extracted
+                    )
+                )
+
+                # Write bookmark
+                key_properties = get_key_properties(catalog_entry)
+                max_pk_values = singer.get_bookmark(
+                    state, catalog_entry.tap_stream_id, 'max_pk_values'
+                )
+
+                if max_pk_values:
+                    last_pk_fetched = {
+                        k:v for k, v in record.record.items()
+                        if k in key_properties
+                    }
+
+                    state = singer.write_bookmark(
+                        state, catalog_entry.tap_stream_id,
+                        'last_pk_fetched', last_pk_fetched
+                    )
+
+                    singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
+
+                batch_file_index += 1
+                rows = cursor.fetchmany(export_batch_rows)
 
     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))

--- a/tap_mysql/sync_strategies/full_table.py
+++ b/tap_mysql/sync_strategies/full_table.py
@@ -117,7 +117,7 @@ def generate_pk_clause(catalog_entry, state):
     return sql
 
 
-def sync_table(mysql_conn, catalog_entry, state, columns, stream_version):
+def sync_table(mysql_conn, catalog_entry, state, columns, stream_version, batch):
     common.whitelist_bookmark_keys(generate_bookmark_keys(catalog_entry), catalog_entry.tap_stream_id, state)
 
     bookmark = state.get('bookmarks', {}).get(catalog_entry.tap_stream_id, {})
@@ -173,7 +173,8 @@ def sync_table(mysql_conn, catalog_entry, state, columns, stream_version):
                               select_sql,
                               columns,
                               stream_version,
-                              params)
+                              params,
+                              batch)
 
     # clear max pk value and last pk fetched upon successful sync
     singer.clear_bookmark(state, catalog_entry.tap_stream_id, 'max_pk_values')

--- a/tap_mysql/sync_strategies/incremental.py
+++ b/tap_mysql/sync_strategies/incremental.py
@@ -12,7 +12,7 @@ import tap_mysql.sync_strategies.common as common
 BOOKMARK_KEYS = {'replication_key', 'replication_key_value', 'version'}
 
 
-def sync_table(mysql_conn, catalog_entry, state, columns):
+def sync_table(mysql_conn, catalog_entry, state, columns, batch):
     common.whitelist_bookmark_keys(BOOKMARK_KEYS, catalog_entry.tap_stream_id, state)
 
     catalog_metadata = metadata.to_map(catalog_entry.metadata)
@@ -65,10 +65,7 @@ def sync_table(mysql_conn, catalog_entry, state, columns):
             elif replication_key_metadata is not None:
                 select_sql += ' ORDER BY `{}` ASC'.format(replication_key_metadata)
 
-            common.sync_query(cur,
-                              catalog_entry,
-                              state,
-                              select_sql,
-                              columns,
-                              stream_version,
-                              params)
+            common.sync_query(
+                cur, catalog_entry, state, select_sql,
+                columns, stream_version, params, batch
+            )


### PR DESCRIPTION
## Problem

'Fast Sync' is a feature of pipelinewise, not singer. This means folks using this target outside of pipelinewise do not benefit (*cough*Meltano). This PR enables fast-sync, configurable by setting "fast_sync": true in your config.json file.

WARNING: fast sync must be supported and enabled by both tap and target for it to work.

## Proposed changes

Piping records between tap and target using STDOUT is slow for tables with large numbers of rows. Therefore I have implemented record batching, with a collection of records serialized to disk and a pointer written into a new BatchRecord. As I have no direct control over the Singer spec, this batch record appears as a standard RECORD, using config and a reserved key (__fast_sync_message__) to identify these new messages.

My intention is that `FULL_TABLE` and first-run `LOG_BASED` replication happens in batch _if_ `fast_sync` is enabled. The behaviour of `INCREMENTAL` tables remains unaffected, in part because there is no obvious branch-point to wedge a `if batch:` statement and we don't need it for testing. Having reviewed the code since this PR, it should be possible to implement `fast_sync` for incremental tables by removing the `if replication_method == 'INCREMENTAL'` check on line 176 of `common.py` and updating the checkpointing logic on lines 260 to 277. Will add this in a future PR.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions